### PR TITLE
Do not create dedicated column for constants

### DIFF
--- a/crates/shielder-circuits/src/config_builder.rs
+++ b/crates/shielder-circuits/src/config_builder.rs
@@ -195,7 +195,7 @@ impl<'cs, F: FieldExt> BaseBuilder<'cs, F> {
     pub fn new(system: &'cs mut ConstraintSystem<F>) -> Self {
         Self {
             advice_pool: ColumnPool::<Advice>::new(),
-            fixed_pool: ColumnPool::<Fixed>::new(system),
+            fixed_pool: ColumnPool::<Fixed>::new(),
             system,
         }
     }


### PR DESCRIPTION
Instead of keeping special fixed column for storing constants, allow storing them in any column from the pool.