### PR TITLE
Improve column load balancing

### DIFF
--- a/crates/shielder-circuits/src/column_pool.rs
+++ b/crates/shielder-circuits/src/column_pool.rs
@@ -57,11 +57,13 @@ impl<C: ColumnType> ColumnPool<C> {
     ///
     /// The index is not guaranteed (some inner load balancing might be applied).
     pub fn get_any(&self) -> Column<C> {
-        let idx = *self
+        let idx = self
             .access_counter
             .borrow()
             .iter()
-            .min()
+            .enumerate()
+            .min_by_key(|&(_, count)| count)
+            .map(|(idx, _)| idx)
             .expect("empty pool");
         self.get(idx)
     }


### PR DESCRIPTION
Implemented a bit better load balancing mechanism - we keep usage counters for every column and `get_any` returns the one that was the least accessed. Beware, unfortunately we cannot track number of regions using particular column, but rather we count consumers, which might not be optimal.

Audit report suggested moving range checking to the 8th advice column. This indeed results in a more compact table: for `Withdraw` this gives 789 rows instead of 804 obtained with the strategy described above. However, unless we are just above 2^k threshold, I would avoid such manual optimizations, because they seem very unnatural and compounding a few of such might lead to a pretty confusing code.