### PR TITLE
Rename Gate's associated type

### DIFF
--- a/crates/shielder-circuits/src/chips/range_check/gate.rs
+++ b/crates/shielder-circuits/src/chips/range_check/gate.rs
@@ -18,14 +18,14 @@ pub struct RangeCheckGate<const CHUNK_SIZE: usize> {
 
 /// The values that are required to construct a range check gate. Pair `(base, shifted)` is expected
 /// to satisfy the inequality: `base - shifted * 2^CHUNK_SIZE < 2^CHUNK_SIZE`.
-pub type RangeCheckGateValues<F> = (AssignedCell<F>, AssignedCell<F>);
+pub type RangeCheckGateInput<F> = (AssignedCell<F>, AssignedCell<F>);
 
 const GATE_NAME: &str = "Range check gate";
 const BASE_OFFSET: usize = 0;
 const SHIFTED_OFFSET: usize = 1;
 
 impl<const CHUNK_SIZE: usize, F: FieldExt> Gate<F> for RangeCheckGate<CHUNK_SIZE> {
-    type Values = RangeCheckGateValues<F>;
+    type Input = RangeCheckGateInput<F>;
     type Advices = Column<Advice>;
 
     /// The gate operates on a single advice column `A` and a table `T`. It enforces that:

--- a/crates/shielder-circuits/src/chips/sum.rs
+++ b/crates/shielder-circuits/src/chips/sum.rs
@@ -5,7 +5,7 @@ use halo2_proofs::{
 
 use crate::{
     gates::{
-        sum::{SumGate, SumGateValues},
+        sum::{SumGate, SumGateInput},
         Gate,
     },
     AssignedCell, Field,
@@ -26,7 +26,7 @@ impl SumChip {
         summand_2: AssignedCell<F>,
         sum: AssignedCell<F>,
     ) -> Result<(), Error> {
-        let gate_input = SumGateValues {
+        let gate_input = SumGateInput {
             summand_1,
             summand_2,
             sum,
@@ -41,7 +41,7 @@ impl SumChip {
         left_sock: AssignedCell<F>,
         right_sock: AssignedCell<F>,
     ) -> Result<(), Error> {
-        let gate_input = SumGateValues {
+        let gate_input = SumGateInput {
             summand_1: left_sock,
             summand_2: self.zero(layouter)?,
             sum: right_sock,

--- a/crates/shielder-circuits/src/circuits/merkle/chip.rs
+++ b/crates/shielder-circuits/src/circuits/merkle/chip.rs
@@ -10,7 +10,7 @@ use crate::{
     column_pool::ColumnPool,
     consts::merkle_constants::ARITY,
     gates::{
-        membership::{MembershipGate, MembershipGateValues},
+        membership::{MembershipGate, MembershipGateInput},
         Gate,
     },
     instance_wrapper::InstanceWrapper,
@@ -44,7 +44,7 @@ impl<F: FieldExt> MerkleChip<F> {
             // 1. Check if the new level contains the current root.
             self.membership_gate.apply_in_new_region(
                 layouter,
-                MembershipGateValues {
+                MembershipGateInput {
                     needle: current_root,
                     haystack: level.clone(),
                 },

--- a/crates/shielder-circuits/src/gates/membership.rs
+++ b/crates/shielder-circuits/src/gates/membership.rs
@@ -18,7 +18,7 @@ pub struct MembershipGate<const N: usize> {
 }
 
 #[derive(Clone, Debug)]
-pub struct MembershipGateValues<F: Field, const N: usize> {
+pub struct MembershipGateInput<F: Field, const N: usize> {
     pub needle: AssignedCell<F>,
     pub haystack: [AssignedCell<F>; N],
 }
@@ -28,7 +28,7 @@ const ADVICE_OFFSET: usize = 0;
 const GATE_NAME: &str = "Membership gate";
 
 impl<F: Field, const N: usize> Gate<F> for MembershipGate<N> {
-    type Values = MembershipGateValues<F, N>;
+    type Input = MembershipGateInput<F, N>;
     type Advices = (Column<Advice>, [Column<Advice>; N]);
 
     /// The gate operates on a single advice column `needle` and `N` advice columns `haystack`. It
@@ -63,7 +63,7 @@ impl<F: Field, const N: usize> Gate<F> for MembershipGate<N> {
     fn apply_in_new_region(
         &self,
         layouter: &mut impl Layouter<F>,
-        input: Self::Values,
+        input: Self::Input,
     ) -> Result<(), Error> {
         layouter.assign_region(
             || GATE_NAME,

--- a/crates/shielder-circuits/src/gates/mod.rs
+++ b/crates/shielder-circuits/src/gates/mod.rs
@@ -13,8 +13,8 @@ pub mod sum;
 ///   2. Within a dedicated region, constrained-copies the inputs to the region, enables a selector
 ///      and applies some constraints.
 pub trait Gate<F: Field>: Sized {
-    /// The type that represents the values structure that the gate operates on.
-    type Values;
+    /// Represents the value structure that the gate operates on.
+    type Input;
     /// How the gate expects advice columns to be passed to it during creation.
     type Advices;
 
@@ -27,6 +27,6 @@ pub trait Gate<F: Field>: Sized {
     fn apply_in_new_region(
         &self,
         layouter: &mut impl Layouter<F>,
-        input: Self::Values,
+        input: Self::Input,
     ) -> Result<(), Error>;
 }

--- a/crates/shielder-circuits/src/gates/sum.rs
+++ b/crates/shielder-circuits/src/gates/sum.rs
@@ -17,7 +17,7 @@ pub struct SumGate {
 }
 
 #[derive(Clone, Debug)]
-pub struct SumGateValues<F: Field> {
+pub struct SumGateInput<F: Field> {
     pub summand_1: AssignedCell<F>,
     pub summand_2: AssignedCell<F>,
     pub sum: AssignedCell<F>,
@@ -28,7 +28,7 @@ const ADVICE_OFFSET: usize = 0;
 const GATE_NAME: &str = "Sum gate";
 
 impl<F: Field> Gate<F> for SumGate {
-    type Values = SumGateValues<F>;
+    type Input = SumGateInput<F>;
     type Advices = [Column<Advice>; 3];
 
     /// The gate operates on three advice columns `A`, `B`, and `C`. It enforces that:
@@ -50,7 +50,7 @@ impl<F: Field> Gate<F> for SumGate {
     fn apply_in_new_region(
         &self,
         layouter: &mut impl Layouter<F>,
-        input: Self::Values,
+        input: Self::Input,
     ) -> Result<(), Error> {
         layouter.assign_region(
             || GATE_NAME,


### PR DESCRIPTION
`*Values` is a confusing relict from the times, when gates used to return copied cells. Now it's simply input and that's how it was renamed to.