### PR TITLE
Remove CHUNK_SIZE const generic

### DIFF
--- a/crates/shielder-circuits/benches/bench.rs
+++ b/crates/shielder-circuits/benches/bench.rs
@@ -6,10 +6,7 @@ use shielder_circuits::{
         deposit::DepositProverKnowledge, merkle::MerkleProverKnowledge,
         new_account::NewAccountProverKnowledge, withdraw::WithdrawProverKnowledge,
     },
-    consts::{
-        merkle_constants::{ARITY, NOTE_TREE_HEIGHT, WIDTH},
-        RANGE_PROOF_CHUNK_SIZE,
-    },
+    consts::merkle_constants::{ARITY, NOTE_TREE_HEIGHT, WIDTH},
     generate_keys_with_min_k, generate_proof, generate_setup_params, verify, CircuitCost,
     ProverKnowledge, MAX_K,
 };
@@ -110,7 +107,7 @@ criterion_group! {
 }
 
 pub fn bench_deposit(c: &mut Criterion) {
-    bench_circuit::<DepositProverKnowledge<Fr, RANGE_PROOF_CHUNK_SIZE>>(c, "NoteDepositCircuit")
+    bench_circuit::<DepositProverKnowledge<Fr>>(c, "NoteDepositCircuit")
 }
 
 criterion_group! {
@@ -130,7 +127,7 @@ criterion_group! {
 }
 
 pub fn bench_withdraw(c: &mut Criterion) {
-    bench_circuit::<WithdrawProverKnowledge<Fr, RANGE_PROOF_CHUNK_SIZE>>(c, "NoteWithdrawCircuit")
+    bench_circuit::<WithdrawProverKnowledge<Fr>>(c, "NoteWithdrawCircuit")
 }
 
 criterion_group! {

--- a/crates/shielder-circuits/src/bin/measure_circuits.rs
+++ b/crates/shielder-circuits/src/bin/measure_circuits.rs
@@ -8,7 +8,7 @@ use shielder_circuits::{
         deposit::DepositProverKnowledge, merkle::MerkleProverKnowledge,
         new_account::NewAccountProverKnowledge, withdraw::WithdrawProverKnowledge, Params,
     },
-    consts::{merkle_constants::NOTE_TREE_HEIGHT, RANGE_PROOF_CHUNK_SIZE},
+    consts::merkle_constants::NOTE_TREE_HEIGHT,
     generate_keys_with_min_k, generate_proof, generate_setup_params, ProverKnowledge, F, G1, MAX_K,
     SERDE_FORMAT,
 };
@@ -53,7 +53,7 @@ fn measure_circuit<PK: ProverKnowledge<F>>(circuit_name: &str) {
 
 fn main() {
     measure_circuit::<NewAccountProverKnowledge<F>>("New account");
-    measure_circuit::<DepositProverKnowledge<F, RANGE_PROOF_CHUNK_SIZE>>("Deposit");
-    measure_circuit::<WithdrawProverKnowledge<F, RANGE_PROOF_CHUNK_SIZE>>("Withdraw");
+    measure_circuit::<DepositProverKnowledge<F>>("Deposit");
+    measure_circuit::<WithdrawProverKnowledge<F>>("Withdraw");
     measure_circuit::<MerkleProverKnowledge<NOTE_TREE_HEIGHT, F>>("Merkle");
 }

--- a/crates/shielder-circuits/src/chips/id_hiding.rs
+++ b/crates/shielder-circuits/src/chips/id_hiding.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct IdHidingChip<F: FieldExt, const CHUNK_SIZE: usize> {
+pub struct IdHidingChip<F: FieldExt> {
     pub poseidon: PoseidonChip<F>,
-    pub range_check: RangeCheckChip<CHUNK_SIZE>,
+    pub range_check: RangeCheckChip,
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> IdHidingChip<F, CHUNK_SIZE> {
-    pub fn new(poseidon: PoseidonChip<F>, range_check: RangeCheckChip<CHUNK_SIZE>) -> Self {
+impl<F: FieldExt> IdHidingChip<F> {
+    pub fn new(poseidon: PoseidonChip<F>, range_check: RangeCheckChip) -> Self {
         Self {
             poseidon,
             range_check,

--- a/crates/shielder-circuits/src/chips/range_check/gate.rs
+++ b/crates/shielder-circuits/src/chips/range_check/gate.rs
@@ -6,14 +6,16 @@ use halo2_proofs::{
     poly::Rotation,
 };
 
-use crate::{gates::Gate, range_table::RangeTable, AssignedCell, FieldExt};
+use crate::{
+    consts::RANGE_PROOF_CHUNK_SIZE, gates::Gate, range_table::RangeTable, AssignedCell, FieldExt,
+};
 
-/// Represents inequality: `base - shifted * 2^CHUNK_SIZE < 2^CHUNK_SIZE`.
+/// Represents inequality: `base - shifted * 2^RANGE_PROOF_CHUNK_SIZE < 2^RANGE_PROOF_CHUNK_SIZE`.
 #[derive(Clone, Debug)]
-pub struct RangeCheckGate<const CHUNK_SIZE: usize> {
+pub struct RangeCheckGate {
     advice: Column<Advice>,
     selector: Selector,
-    table: RangeTable<CHUNK_SIZE>,
+    table: RangeTable<{ RANGE_PROOF_CHUNK_SIZE }>,
 }
 
 /// The values that are required to construct a range check gate. Pair `(base, shifted)` is expected
@@ -24,7 +26,7 @@ const GATE_NAME: &str = "Range check gate";
 const BASE_OFFSET: usize = 0;
 const SHIFTED_OFFSET: usize = 1;
 
-impl<const CHUNK_SIZE: usize, F: FieldExt> Gate<F> for RangeCheckGate<CHUNK_SIZE> {
+impl<F: FieldExt> Gate<F> for RangeCheckGate {
     type Input = RangeCheckGateInput<F>;
     type Advices = Column<Advice>;
 
@@ -51,7 +53,7 @@ impl<const CHUNK_SIZE: usize, F: FieldExt> Gate<F> for RangeCheckGate<CHUNK_SIZE
             //
             // Therefore, we recover the chunk as:
             //  - chunk = base - shifted * SCALE
-            let scale = Expression::Constant(F::from(1 << CHUNK_SIZE));
+            let scale = Expression::Constant(F::from(1 << RANGE_PROOF_CHUNK_SIZE));
             let chunk = base - shifted * scale;
 
             vec![(selector * chunk, table.column())]

--- a/crates/shielder-circuits/src/chips/range_check/mod.rs
+++ b/crates/shielder-circuits/src/chips/range_check/mod.rs
@@ -7,6 +7,7 @@ use halo2_proofs::{
 use crate::{
     chips::{range_check::running_sum::running_sum, sum::SumChip},
     column_pool::ColumnPool,
+    consts::RANGE_PROOF_CHUNK_SIZE,
     embed::Embed,
     gates::Gate,
     AssignedCell, FieldExt,
@@ -17,13 +18,13 @@ mod gate;
 mod running_sum;
 
 #[derive(Clone, Debug)]
-pub struct RangeCheckChip<const CHUNK_SIZE: usize> {
-    range_gate: RangeCheckGate<CHUNK_SIZE>,
+pub struct RangeCheckChip {
+    range_gate: RangeCheckGate,
     sum_chip: SumChip,
     advice_pool: ColumnPool<Advice>,
 }
 
-impl<const CHUNK_SIZE: usize> RangeCheckChip<CHUNK_SIZE> {
+impl RangeCheckChip {
     pub fn new<F: FieldExt>(
         system: &mut ConstraintSystem<F>,
         advice_pool: ColumnPool<Advice>,
@@ -45,7 +46,8 @@ impl<const CHUNK_SIZE: usize> RangeCheckChip<CHUNK_SIZE> {
     ) -> Result<(), Error> {
         // PROVER STEPS:
         // 1. Represent `value` as a running sum (compute it outside of the circuit).
-        let running_sum_off_circuit = running_sum(value.value().copied(), CHUNK_SIZE, CHUNKS);
+        let running_sum_off_circuit =
+            running_sum(value.value().copied(), RANGE_PROOF_CHUNK_SIZE, CHUNKS);
         // 2. Embed the running sum into the circuit.
         let running_sum_cells =
             running_sum_off_circuit.embed(layouter, &self.advice_pool, "running_sum")?;

--- a/crates/shielder-circuits/src/circuits/deposit/chip.rs
+++ b/crates/shielder-circuits/src/circuits/deposit/chip.rs
@@ -29,20 +29,20 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct DepositChip<F: FieldExt, const CHUNK_SIZE: usize> {
+pub struct DepositChip<F: FieldExt> {
     pub advice_pool: ColumnPool<Advice>,
     pub public_inputs: InstanceWrapper<DepositInstance>,
     pub poseidon: PoseidonChip<F>,
-    pub range_check: RangeCheckChip<CHUNK_SIZE>,
+    pub range_check: RangeCheckChip,
     pub merkle: MerkleChip<F>,
     pub sum: SumChip,
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> DepositChip<F, CHUNK_SIZE> {
+impl<F: FieldExt> DepositChip<F> {
     pub fn check_old_note(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &DepositProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &DepositProverKnowledge<AssignedCell<F>>,
         todo: &mut Todo<DepositConstraints>,
     ) -> Result<(), Error> {
         let old_note = NoteChip::new(self.poseidon.clone(), self.advice_pool.clone()).note(
@@ -67,7 +67,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> DepositChip<F, CHUNK_SIZE> {
     pub fn check_old_nullifier(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &DepositProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &DepositProverKnowledge<AssignedCell<F>>,
         todo: &mut Todo<DepositConstraints>,
     ) -> Result<(), Error> {
         let hashed_old_nullifier = hash(
@@ -85,7 +85,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> DepositChip<F, CHUNK_SIZE> {
     pub fn check_id_hiding(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &DepositProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &DepositProverKnowledge<AssignedCell<F>>,
         todo: &mut Todo<DepositConstraints>,
     ) -> Result<(), Error> {
         let id_hiding = IdHidingChip::new(self.poseidon.clone(), self.range_check.clone())
@@ -102,7 +102,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> DepositChip<F, CHUNK_SIZE> {
     pub fn check_new_note(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &DepositProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &DepositProverKnowledge<AssignedCell<F>>,
         intermediate_values: &IntermediateValues<AssignedCell<F>>,
         todo: &mut Todo<DepositConstraints>,
     ) -> Result<(), Error> {

--- a/crates/shielder-circuits/src/circuits/deposit/knowledge.rs
+++ b/crates/shielder-circuits/src/circuits/deposit/knowledge.rs
@@ -24,11 +24,11 @@ use crate::{
 /// and some do not appear as inputs at all, but are just intermediate advice values.
 #[derive(Clone, Debug, Default)]
 #[embeddable(
-    receiver = "DepositProverKnowledge<Value<F>, CHUNK_SIZE>",
-    impl_generics = "<F: FieldExt, const CHUNK_SIZE: usize>",
-    embedded = "DepositProverKnowledge<crate::AssignedCell<F>, CHUNK_SIZE>"
+    receiver = "DepositProverKnowledge<Value<F>>",
+    impl_generics = "<F: FieldExt>",
+    embedded = "DepositProverKnowledge<crate::AssignedCell<F>>"
 )]
-pub struct DepositProverKnowledge<F, const CHUNK_SIZE: usize> {
+pub struct DepositProverKnowledge<F> {
     // Old note
     pub id: F,
     pub nullifier_old: F,
@@ -48,7 +48,7 @@ pub struct DepositProverKnowledge<F, const CHUNK_SIZE: usize> {
     pub deposit_value: F,
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> DepositProverKnowledge<Value<F>, CHUNK_SIZE> {
+impl<F: FieldExt> DepositProverKnowledge<Value<F>> {
     pub fn compute_intermediate_values(&self) -> IntermediateValues<Value<F>> {
         IntermediateValues {
             account_new_balance: self.account_old_balance + self.deposit_value,
@@ -56,10 +56,8 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> DepositProverKnowledge<Value<F>, CHUN
     }
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> ProverKnowledge<F>
-    for DepositProverKnowledge<F, CHUNK_SIZE>
-{
-    type Circuit = DepositCircuit<F, CHUNK_SIZE>;
+impl<F: FieldExt> ProverKnowledge<F> for DepositProverKnowledge<F> {
+    type Circuit = DepositCircuit<F>;
     type PublicInput = DepositInstance;
 
     /// Creates a random example with correct inputs. All values are random except for the deposit
@@ -107,9 +105,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> ProverKnowledge<F>
     }
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> PublicInputProvider<DepositInstance, F>
-    for DepositProverKnowledge<F, CHUNK_SIZE>
-{
+impl<F: FieldExt> PublicInputProvider<DepositInstance, F> for DepositProverKnowledge<F> {
     fn compute_public_input(&self, instance_id: DepositInstance) -> F {
         match instance_id {
             DepositInstance::IdHiding => hash(&[hash(&[self.id]), self.nonce]),

--- a/crates/shielder-circuits/src/circuits/withdraw/chip.rs
+++ b/crates/shielder-circuits/src/circuits/withdraw/chip.rs
@@ -30,20 +30,20 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct WithdrawChip<F: FieldExt, const CHUNK_SIZE: usize> {
+pub struct WithdrawChip<F: FieldExt> {
     pub advice_pool: ColumnPool<Advice>,
     pub public_inputs: InstanceWrapper<WithdrawInstance>,
     pub poseidon: PoseidonChip<F>,
     pub merkle: MerkleChip<F>,
-    pub range_check: RangeCheckChip<CHUNK_SIZE>,
+    pub range_check: RangeCheckChip,
     pub sum_chip: SumChip,
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> WithdrawChip<F, CHUNK_SIZE> {
+impl<F: FieldExt> WithdrawChip<F> {
     pub fn check_old_note(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &WithdrawProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &WithdrawProverKnowledge<AssignedCell<F>>,
         todo: &mut Todo<WithdrawConstraints>,
     ) -> Result<(), Error> {
         let old_note = NoteChip::new(self.poseidon.clone(), self.advice_pool.clone()).note(
@@ -68,7 +68,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> WithdrawChip<F, CHUNK_SIZE> {
     pub fn check_old_nullifier(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &WithdrawProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &WithdrawProverKnowledge<AssignedCell<F>>,
         todo: &mut Todo<WithdrawConstraints>,
     ) -> Result<(), Error> {
         let hashed_old_nullifier = hash(
@@ -86,7 +86,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> WithdrawChip<F, CHUNK_SIZE> {
     pub fn check_id_hiding(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &WithdrawProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &WithdrawProverKnowledge<AssignedCell<F>>,
         todo: &mut Todo<WithdrawConstraints>,
     ) -> Result<(), Error> {
         let id_hiding = IdHidingChip::new(self.poseidon.clone(), self.range_check.clone())
@@ -101,7 +101,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> WithdrawChip<F, CHUNK_SIZE> {
     pub fn check_new_note(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &WithdrawProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &WithdrawProverKnowledge<AssignedCell<F>>,
         intermediate_values: &IntermediateValues<AssignedCell<F>>,
         todo: &mut Todo<WithdrawConstraints>,
     ) -> Result<(), Error> {
@@ -148,7 +148,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> WithdrawChip<F, CHUNK_SIZE> {
     pub fn check_commitment(
         &self,
         layouter: &mut impl Layouter<F>,
-        knowledge: &WithdrawProverKnowledge<AssignedCell<F>, CHUNK_SIZE>,
+        knowledge: &WithdrawProverKnowledge<AssignedCell<F>>,
         todo: &mut Todo<WithdrawConstraints>,
     ) -> Result<(), Error> {
         self.public_inputs

--- a/crates/shielder-circuits/src/circuits/withdraw/knowledge.rs
+++ b/crates/shielder-circuits/src/circuits/withdraw/knowledge.rs
@@ -19,11 +19,11 @@ use crate::{
 
 #[derive(Clone, Debug, Default)]
 #[embeddable(
-    receiver = "WithdrawProverKnowledge<Value<F>, CHUNK_SIZE>",
-    impl_generics = "<F: FieldExt, const CHUNK_SIZE: usize>",
-    embedded = "WithdrawProverKnowledge<crate::AssignedCell<F>, CHUNK_SIZE>"
+    receiver = "WithdrawProverKnowledge<Value<F>>",
+    impl_generics = "<F: FieldExt>",
+    embedded = "WithdrawProverKnowledge<crate::AssignedCell<F>>"
 )]
-pub struct WithdrawProverKnowledge<F, const CHUNK_SIZE: usize> {
+pub struct WithdrawProverKnowledge<F> {
     pub withdrawal_value: F,
 
     // Additional public parameters that need to be included in proof
@@ -46,7 +46,7 @@ pub struct WithdrawProverKnowledge<F, const CHUNK_SIZE: usize> {
     pub nonce: F,
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> WithdrawProverKnowledge<Value<F>, CHUNK_SIZE> {
+impl<F: FieldExt> WithdrawProverKnowledge<Value<F>> {
     pub fn compute_intermediate_values(&self) -> IntermediateValues<Value<F>> {
         IntermediateValues {
             new_account_balance: self.account_old_balance - self.withdrawal_value,
@@ -54,10 +54,8 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> WithdrawProverKnowledge<Value<F>, CHU
     }
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> ProverKnowledge<F>
-    for WithdrawProverKnowledge<F, CHUNK_SIZE>
-{
-    type Circuit = WithdrawCircuit<F, CHUNK_SIZE>;
+impl<F: FieldExt> ProverKnowledge<F> for WithdrawProverKnowledge<F> {
+    type Circuit = WithdrawCircuit<F>;
     type PublicInput = WithdrawInstance;
 
     /// TODO: Refactor this test. Having `MAX_ACCOUNT_BALANCE_PASSING_RANGE_CHECK` as the only
@@ -121,9 +119,7 @@ impl<F: FieldExt, const CHUNK_SIZE: usize> ProverKnowledge<F>
     }
 }
 
-impl<F: FieldExt, const CHUNK_SIZE: usize> PublicInputProvider<WithdrawInstance, F>
-    for WithdrawProverKnowledge<F, CHUNK_SIZE>
-{
+impl<F: FieldExt> PublicInputProvider<WithdrawInstance, F> for WithdrawProverKnowledge<F> {
     fn compute_public_input(&self, instance_id: WithdrawInstance) -> F {
         match instance_id {
             WithdrawInstance::IdHiding => hash(&[hash(&[self.id]), self.nonce]),

--- a/crates/shielder-circuits/src/config_builder.rs
+++ b/crates/shielder-circuits/src/config_builder.rs
@@ -17,7 +17,7 @@ pub struct With<T>(T);
 type WithSum = With<SumChip>;
 type WithMerkle<F> = With<MerkleChip<F>>;
 type WithPoseidon<F> = With<PoseidonChip<F>>;
-type WithRangeCheck<const CHUNK_SIZE: usize> = With<RangeCheckChip<{ CHUNK_SIZE }>>;
+type WithRangeCheck = With<RangeCheckChip>;
 
 pub struct ConfigsBuilder<'cs, F: FieldExt, Poseidon, Merkle, Sum, RangeCheck> {
     base_builder: BaseBuilder<'cs, F>,
@@ -122,9 +122,9 @@ impl<'cs, F: FieldExt, Sum> ConfigsBuilder<'cs, F, WithPoseidon<F>, Empty, Sum, 
 impl<'cs, F: FieldExt, Poseidon, Merkle, RangeCheck>
     ConfigsBuilder<'cs, F, Poseidon, Merkle, WithSum, RangeCheck>
 {
-    pub fn range_check<const CHUNK_SIZE: usize>(
+    pub fn range_check(
         mut self,
-    ) -> ConfigsBuilder<'cs, F, Poseidon, Merkle, WithSum, WithRangeCheck<CHUNK_SIZE>> {
+    ) -> ConfigsBuilder<'cs, F, Poseidon, Merkle, WithSum, WithRangeCheck> {
         let system = &mut self.base_builder.system;
         self.base_builder.advice_pool.ensure_capacity(system, 1);
         let advice_pool = self.base_builder.advice_pool.clone();
@@ -141,10 +141,10 @@ impl<'cs, F: FieldExt, Poseidon, Merkle, RangeCheck>
     }
 }
 
-impl<'cs, F: FieldExt, Poseidon, Merkle, Sum, const CHUNK_SIZE: usize>
-    ConfigsBuilder<'cs, F, Poseidon, Merkle, Sum, WithRangeCheck<CHUNK_SIZE>>
+impl<'cs, F: FieldExt, Poseidon, Merkle, Sum>
+    ConfigsBuilder<'cs, F, Poseidon, Merkle, Sum, WithRangeCheck>
 {
-    pub fn resolve_range_check(&self) -> RangeCheckChip<CHUNK_SIZE> {
+    pub fn resolve_range_check(&self) -> RangeCheckChip {
         self.range_check.0.clone()
     }
 }


### PR DESCRIPTION
Similarly to https://github.com/Cardinal-Cryptography/zkOS/pull/258, we drop generic constant for the CHUNK_SIZE in all components. Rationale:
 - this crate is for our usage only; we are not likely to publish it as a general library anytime soon
 - we always use the same constant (from `consts.rs`) as the template argument
